### PR TITLE
Fixed typo and specified encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For the CorPaR classifier, type:
 $ python analyze.py corpar
 ```
 
-The results in the form of preditions are written to TSV files in the folders `results/svm` and `results/corpar` respectively. To analyze them by computing edit distance and B-Cubed F-scores, we use the script `evaluate.py`:
+The results in the form of predictions are written to TSV files in the folders `results/svm` and `results/corpar` respectively. To analyze them by computing edit distance and B-Cubed F-scores, we use the script `evaluate.py`:
 
 ```
 $ python evaluate.py

--- a/evaluate.py
+++ b/evaluate.py
@@ -24,7 +24,7 @@ by_ds = defaultdict(list)
 
 for clf in classifiers:
     for pth in progressbar(list(Path("results", clf).glob("*.tsv"))[:]):
-        with open(pth) as f:
+        with open(pth, "r", encoding="utf-8") as f:
             res = []
             for row in f:
                 res += [[[a.strip() for a in x.split()] for x in row.split("\t")]]


### PR DESCRIPTION
On Windows 10, I had to add the "utf-8" encoding while reading the file in `evaluate.py`.